### PR TITLE
Fix in operator bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,7 @@
 0.9.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
-
-0.9.2 (unreleased)
-------------------
-
-- Nothing changed yet.
+- Fix in operator bug.
 
 
 0.9.1 (2018-08-23)

--- a/flask_jsonapi/utils/sqlalchemy_django_query.py
+++ b/flask_jsonapi/utils/sqlalchemy_django_query.py
@@ -46,8 +46,6 @@ class DjangoQueryMixin(object):
         'lte':          operators.le,
         'contains':     operators.contains_op,
         'notcontains':  operators.notcontains_op,
-        'in':           operators.in_op,
-        'notin':        operators.notin_op,
         'exact':        operators.eq,
         'iexact':       operators.ilike_op,
         'startswith':   operators.startswith_op,
@@ -59,6 +57,11 @@ class DjangoQueryMixin(object):
         'year':         lambda c, x: extract('year', c) == x,
         'month':        lambda c, x: extract('month', c) == x,
         'day':          lambda c, x: extract('day', c) == x
+    }
+
+    _underscore_list_operators = {
+        'in': operators.in_op,
+        'notin': operators.notin_op,
     }
 
     def filter_by(self, **kwargs):
@@ -129,6 +132,10 @@ class DjangoQueryMixin(object):
                 elif token in self._underscore_operators:
                     op = self._underscore_operators[token]
                     q = q.filter(negate_if(op(column, *to_list(value))))
+                    column = None
+                elif token in self._underscore_list_operators:
+                    op = self._underscore_list_operators[token]
+                    q = q.filter(negate_if(op(column, to_list(value))))
                     column = None
                 else:
                     raise ValueError('No idea what to do with %r' % token)

--- a/tests/sqlalchemy_repository/filter_backend/test_sqlalchemy_repository_filter_backend.py
+++ b/tests/sqlalchemy_repository/filter_backend/test_sqlalchemy_repository_filter_backend.py
@@ -87,3 +87,10 @@ class TestFilterMethods:
         users = user_repository.get_list({'experience_level__gte': 9000})
         assert len(users) == 1
         assert users[0].name == 'Darth Vader'
+
+    def test_in(self, user_repository):
+        user_repository.create({'name': 'Mr. Bean', 'experience_level': 3})
+        user_repository.create({'name': 'Darth Vader', 'experience_level': 9000})
+        user_repository.create({'name': 'Marcin Kopec', 'experience_level': 420})
+        users = user_repository.get_list({'name__in': ['Mr. Bean', 'Marcin Kopec']})
+        assert len(users) == 2


### PR DESCRIPTION
`File "/usr/local/lib/python3.7/site-packages/flask_jsonapi/utils/sqlalchemy_django_query.py", line 131, in _filter_or_exclude
    q = q.filter(negate_if(op(column, *to_list(value))))
TypeError: in_op() takes 2 positional arguments but 3 were given`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/flask-jsonapi/36)
<!-- Reviewable:end -->
