### PR TITLE
Allow overriding resource action methods in protected views.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow overriding resource action methods in protected views.
 
 
 1.2.0 (2021-11-22)

--- a/flask_jsonapi/permissions/views.py
+++ b/flask_jsonapi/permissions/views.py
@@ -5,7 +5,6 @@ from flask_jsonapi import ResourceRepositoryDetailView
 from flask_jsonapi import ResourceRepositoryListView
 from flask_jsonapi import ResourceRepositoryViewSet
 from flask_jsonapi import descriptors
-from flask_jsonapi import exceptions
 
 from . import checkers
 
@@ -37,18 +36,6 @@ class ProtectedListView(ResourceRepositoryListView, abc.ABC):
     def __init__(self, permission_checker: checkers.PermissionChecker, **kwargs):
         super().__init__(**kwargs)
         self.permission_checker = permission_checker
-
-    def get(self, *args, **kwargs):
-        try:
-            return super().get(*args, **kwargs)
-        except checkers.PermissionException:
-            raise exceptions.ForbiddenError("You don't have permissions")
-
-    def post(self, *args, **kwargs):
-        try:
-            return super().post(*args, **kwargs)
-        except checkers.PermissionException:
-            raise exceptions.ForbiddenError("You don't have permissions")
 
     def read_many(self, filters: dict, **kwargs):
         filters = self._apply_permission_filter(filters)

--- a/flask_jsonapi/permissions/views.py
+++ b/flask_jsonapi/permissions/views.py
@@ -8,7 +8,7 @@ from flask_jsonapi.permissions import checkers
 logger = logging.getLogger(__name__)
 
 
-class ProtectedDetailView(resource_repository_views.ResourceRepositoryDetailView):
+class ProtectedDetailViewMixin:
     def __init__(self, permission_checker: checkers.PermissionChecker, **kwargs):
         super().__init__(**kwargs)
         self.permission_checker = permission_checker
@@ -38,7 +38,7 @@ class ProtectedDetailView(resource_repository_views.ResourceRepositoryDetailView
         return super().update(resource.id, data, **kwargs)
 
 
-class ProtectedListView(resource_repository_views.ResourceRepositoryListView, abc.ABC):
+class ProtectedListViewMixin(abc.ABC):
     def __init__(self, permission_checker: checkers.PermissionChecker, **kwargs):
         super().__init__(**kwargs)
         self.permission_checker = permission_checker
@@ -65,6 +65,14 @@ class ProtectedListView(resource_repository_views.ResourceRepositoryListView, ab
 
     def protected_create(self, data: dict, **kwargs):
         return super().create(data, **kwargs)
+
+
+class ProtectedDetailView(ProtectedDetailViewMixin, resource_repository_views.ResourceRepositoryDetailView):
+    pass
+
+
+class ProtectedListView(ProtectedListViewMixin, resource_repository_views.ResourceRepositoryListView):
+    pass
 
 
 class ProtectedViewSet(resource_repository_views.ResourceRepositoryViewSet):

--- a/flask_jsonapi/permissions/views.py
+++ b/flask_jsonapi/permissions/views.py
@@ -1,17 +1,14 @@
 import abc
 import logging
 
-from flask_jsonapi import ResourceRepositoryDetailView
-from flask_jsonapi import ResourceRepositoryListView
-from flask_jsonapi import ResourceRepositoryViewSet
 from flask_jsonapi import descriptors
-
-from . import checkers
+from flask_jsonapi import resource_repository_views
+from flask_jsonapi.permissions import checkers
 
 logger = logging.getLogger(__name__)
 
 
-class ProtectedDetailView(ResourceRepositoryDetailView):
+class ProtectedDetailView(resource_repository_views.ResourceRepositoryDetailView):
     def __init__(self, permission_checker: checkers.PermissionChecker, **kwargs):
         super().__init__(**kwargs)
         self.permission_checker = permission_checker
@@ -32,7 +29,7 @@ class ProtectedDetailView(ResourceRepositoryDetailView):
         return super().update(id, data, **kwargs)
 
 
-class ProtectedListView(ResourceRepositoryListView, abc.ABC):
+class ProtectedListView(resource_repository_views.ResourceRepositoryListView, abc.ABC):
     def __init__(self, permission_checker: checkers.PermissionChecker, **kwargs):
         super().__init__(**kwargs)
         self.permission_checker = permission_checker
@@ -55,7 +52,7 @@ class ProtectedListView(ResourceRepositoryListView, abc.ABC):
         return super().create(data, **kwargs)
 
 
-class ProtectedViewSet(ResourceRepositoryViewSet):
+class ProtectedViewSet(resource_repository_views.ResourceRepositoryViewSet):
     detail_view_cls = ProtectedDetailView
     list_view_cls: ProtectedListView
     permission_checker: checkers.PermissionChecker = descriptors.NotImplementedProperty('permission_checker')

--- a/flask_jsonapi/permissions/views.py
+++ b/flask_jsonapi/permissions/views.py
@@ -14,19 +14,28 @@ class ProtectedDetailView(resource_repository_views.ResourceRepositoryDetailView
         self.permission_checker = permission_checker
 
     def read(self, id):
-        resource = super().read(id)
+        resource = self.protected_read(id)
         resource = self.permission_checker.check_read_permission(resource=resource)
         return resource
 
+    def protected_read(self, id):
+        return super().read(id)
+
     def destroy(self, id):
-        resource = super().read(id)
+        resource = self.protected_read(id)
         resource = self.permission_checker.check_destroy_permission(resource=resource)
+        return self.protected_destroy(resource)
+
+    def protected_destroy(self, resource):
         return super().destroy(resource.id)
 
     def update(self, id, data, **kwargs):
-        resource = super().read(id)
+        resource = self.protected_read(id)
         resource, data = self.permission_checker.check_update_permission(resource=resource, data=data)
-        return super().update(id, data, **kwargs)
+        return self.protected_update(resource, data, **kwargs)
+
+    def protected_update(self, resource, data, **kwargs):
+        return super().update(resource.id, data, **kwargs)
 
 
 class ProtectedListView(resource_repository_views.ResourceRepositoryListView, abc.ABC):
@@ -36,7 +45,7 @@ class ProtectedListView(resource_repository_views.ResourceRepositoryListView, ab
 
     def read_many(self, filters: dict, **kwargs):
         filters = self._apply_permission_filter(filters)
-        resources = super().read_many(filters, **kwargs)
+        resources = self.protected_read_many(filters, **kwargs)
         length_before_permission = len(resources)
         resources = self.permission_checker.check_list_permission(resources=resources)
         if length_before_permission != len(resources):
@@ -47,8 +56,14 @@ class ProtectedListView(resource_repository_views.ResourceRepositoryListView, ab
     def _apply_permission_filter(self, filters: dict) -> dict:
         pass
 
+    def protected_read_many(self, filters, **kwargs):
+        return super().read_many(filters, **kwargs)
+
     def create(self, data: dict, **kwargs):
         data = self.permission_checker.check_create_permission(data=data)
+        return self.protected_create(data, **kwargs)
+
+    def protected_create(self, data: dict, **kwargs):
         return super().create(data, **kwargs)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import flask
 import pytest
 
+from flask import testing
+
 
 @pytest.fixture
 def app():
@@ -19,3 +21,17 @@ def api(app):
 def test_client(app):
     with app.test_client() as client:
         yield client
+
+
+class JSONAPIClient(testing.FlaskClient):
+    def open(self, *args, **kwargs):
+        headers = kwargs.setdefault('headers', {})
+        headers.setdefault('Content-Type', 'application/vnd.api+json')
+        headers.setdefault('Accept', 'application/vnd.api+json')
+        return super().open(*args, **kwargs)
+
+
+@pytest.fixture
+def jsonapi_client(app):
+    app.test_client_class = JSONAPIClient
+    return app.test_client()

--- a/tests/permissions/test_views.py
+++ b/tests/permissions/test_views.py
@@ -1,0 +1,246 @@
+import uuid
+
+from unittest import mock
+
+import marshmallow_jsonapi
+import pytest
+
+from marshmallow_jsonapi import fields
+
+from flask_jsonapi import exceptions
+from flask_jsonapi import permissions
+
+ALLOWED_PARENT_ID = '11111111-1111-1111-1111-111111111111'
+NOT_ALLOWED_PARENT_ID = '22222222-2222-2222-2222-222222222222'
+
+
+def viewset_factory(repository_mock):
+    class ExampleResourceSchema(marshmallow_jsonapi.Schema):
+        id = fields.UUID(required=True)
+        parent_id = fields.UUID(required=True)
+        content = fields.String(required=False)
+
+        class Meta:
+            type_ = 'example'
+            self_view_many = 'example_list'
+            self_view = 'example_detail'
+            self_view_kwargs = {'example_id': '<id>'}
+            strict = True
+
+    class ExampleProtectedListView(permissions.ProtectedListView):
+        def _apply_permission_filter(self, filters: dict):
+            filters['parent_id'] = self.permission_checker.get_allowed_parent_id()
+            return filters
+
+    class ExamplePermissionChecker(permissions.ObjectLevelPermissionChecker):
+        object_id_attribute = 'parent_id'
+
+        def has_permission(self, object_id, action) -> bool:
+            return str(object_id) == self.get_allowed_parent_id()
+
+        def get_allowed_parent_id(self):
+            return ALLOWED_PARENT_ID
+
+    class ExampleViewSet(permissions.ProtectedViewSet):
+        list_view_cls = ExampleProtectedListView
+        permission_checker = ExamplePermissionChecker()
+        repository = repository_mock
+        schema = ExampleResourceSchema
+
+    return ExampleViewSet()
+
+
+@pytest.fixture
+def repository():
+    return mock.Mock()
+
+
+@pytest.fixture
+def configured_api(api, repository):
+    view_set = viewset_factory(repository)
+    api.repository(view_set, 'example', '/examples')
+
+
+def resource_factory(id=None, parent_id=None, content=None):
+    object = mock.Mock()
+    object.id = uuid.uuid4() if id is None else id
+    object.parent_id = uuid.uuid4() if parent_id is None else parent_id
+    object.content = 'Sample content' if content is None else content
+    return object
+
+
+@pytest.mark.usefixtures('configured_api')
+class TestProtectedViewSet:
+    def test_list(self, jsonapi_client, repository):
+        repository.get_list.return_value = [
+            resource_factory(parent_id=ALLOWED_PARENT_ID),
+            resource_factory(parent_id=NOT_ALLOWED_PARENT_ID),
+        ]
+
+        response = jsonapi_client.get('/examples')
+
+        assert response.status_code == 200
+        response_body = response.get_json(force=True)
+        assert len(response_body['data']) == 1
+        assert response_body['data'][0]['attributes']['parent_id'] == ALLOWED_PARENT_ID
+        repository.get_list.assert_called_with({'parent_id': '11111111-1111-1111-1111-111111111111'}, (), {})
+
+    def test_list_if_no_permissions(self, jsonapi_client, repository):
+        repository.get_list.return_value = [
+            resource_factory(parent_id=NOT_ALLOWED_PARENT_ID),
+            resource_factory(parent_id=NOT_ALLOWED_PARENT_ID),
+        ]
+
+        response = jsonapi_client.get('/examples')
+
+        assert response.status_code == 200
+        response_body = response.get_json(force=True)
+        assert response_body['data'] == []
+        repository.get_list.assert_called_with({'parent_id': '11111111-1111-1111-1111-111111111111'}, (), {})
+
+    def test_details(self, jsonapi_client, repository):
+        repository.get_detail.return_value = resource_factory(
+            id='33333333-3333-3333-3333-333333333333',
+            parent_id=ALLOWED_PARENT_ID,
+        )
+
+        response = jsonapi_client.get('/examples/33333333-3333-3333-3333-333333333333')
+
+        assert response.status_code == 200
+        response_body = response.get_json(force=True)
+        assert response_body['data']['attributes']['parent_id'] == ALLOWED_PARENT_ID
+        repository.get_detail.assert_called_with('33333333-3333-3333-3333-333333333333')
+
+    def test_details_if_no_permissions(self, jsonapi_client, repository):
+        repository.get_detail.return_value = resource_factory(
+            id='33333333-3333-3333-3333-333333333333',
+            parent_id=NOT_ALLOWED_PARENT_ID,
+        )
+
+        response = jsonapi_client.get('/examples/33333333-3333-3333-3333-333333333333')
+
+        assert response.status_code == 403
+        repository.get_detail.assert_called_with('33333333-3333-3333-3333-333333333333')
+
+    def test_details_if_does_not_exist(self, jsonapi_client, repository):
+        repository.get_detail.side_effect = exceptions.ObjectNotFound(source={}, detail='')
+
+        response = jsonapi_client.get('/examples/33333333-3333-3333-3333-333333333333')
+
+        assert response.status_code == 404
+        repository.get_detail.assert_called_with('33333333-3333-3333-3333-333333333333')
+
+    def test_update(self, jsonapi_client, repository):
+        repository.get_detail.return_value = resource_factory(
+            id='33333333-3333-3333-3333-333333333333',
+            parent_id=ALLOWED_PARENT_ID,
+            content='Initial content.',
+        )
+
+        response = jsonapi_client.patch(
+            '/examples/33333333-3333-3333-3333-333333333333',
+            json={
+                'data': {
+                    'type': 'example',
+                    'id': '33333333-3333-3333-3333-333333333333',
+                    'attributes': {
+                        'content': 'Changed content.',
+                    },
+                },
+            },
+        )
+
+        assert response.status_code == 204
+        repository.get_detail.assert_called_with('33333333-3333-3333-3333-333333333333')
+        repository.update.assert_called_with({
+            'id': '33333333-3333-3333-3333-333333333333',
+            'content': 'Changed content.'
+        })
+
+    def test_update_if_no_permissions(self, jsonapi_client, repository):
+        repository.get_detail.return_value = resource_factory(
+            id='33333333-3333-3333-3333-333333333333',
+            parent_id=NOT_ALLOWED_PARENT_ID,
+            content='Initial content.',
+        )
+
+        response = jsonapi_client.patch(
+            '/examples/33333333-3333-3333-3333-333333333333',
+            json={
+                'data': {
+                    'type': 'example',
+                    'id': '33333333-3333-3333-3333-333333333333',
+                    'attributes': {
+                        'content': 'Changed content.',
+                    },
+                },
+            },
+        )
+
+        assert response.status_code == 403
+        repository.get_detail.assert_called_with('33333333-3333-3333-3333-333333333333')
+        repository.update.assert_not_called()
+
+    def test_delete(self, jsonapi_client, repository):
+        repository.get_detail.return_value = resource_factory(
+            id='33333333-3333-3333-3333-333333333333',
+            parent_id=ALLOWED_PARENT_ID,
+        )
+
+        response = jsonapi_client.delete('/examples/33333333-3333-3333-3333-333333333333')
+
+        assert response.status_code == 204
+        repository.get_detail.assert_called_with('33333333-3333-3333-3333-333333333333')
+        repository.delete.assert_called_with('33333333-3333-3333-3333-333333333333')
+
+    def test_delete_if_no_permissions(self, jsonapi_client, repository):
+        repository.get_detail.return_value = resource_factory(
+            id='33333333-3333-3333-3333-333333333333',
+            parent_id=NOT_ALLOWED_PARENT_ID,
+        )
+
+        response = jsonapi_client.delete('/examples/33333333-3333-3333-3333-333333333333')
+
+        assert response.status_code == 403
+        repository.get_detail.assert_called_with('33333333-3333-3333-3333-333333333333')
+        repository.delete.assert_not_called()
+
+    def test_create(self, jsonapi_client, repository):
+        response = jsonapi_client.post(
+            '/examples',
+            json={
+                'data': {
+                    'type': 'example',
+                    'id': '33333333-3333-3333-3333-333333333333',
+                    'attributes': {
+                        'parent_id': ALLOWED_PARENT_ID,
+                        'content': 'Boring test content text.',
+                    },
+                },
+            },
+        )
+
+        assert response.status_code == 201
+        repository.create.assert_called_with({
+            'id': uuid.UUID('33333333-3333-3333-3333-333333333333'),
+            'parent_id': uuid.UUID('11111111-1111-1111-1111-111111111111'),
+            'content': 'Boring test content text.',
+        })
+
+    def test_create_if_no_permissions(self, jsonapi_client, repository):
+        response = jsonapi_client.post(
+            '/examples',
+            json={
+                'data': {
+                    'type': 'example',
+                    'id': '33333333-3333-3333-3333-333333333333',
+                    'attributes': {
+                        'parent_id': NOT_ALLOWED_PARENT_ID,
+                        'content': 'Boring test content text.',
+                    },
+                },
+            },
+        )
+
+        assert response.status_code == 403
+        repository.create.assert_not_called()


### PR DESCRIPTION
This PR allows creating views that inherit from ProtectedDetailView / ProtectedListView and override "action" methods without losing the permission checking layer. Such views are helpful when your business logic is more complex than a simple CRUD which is implemented by a repository object. Instead of a repository you can use a different object, like a "service" or a "use case".
Those custom views should override methods with "protected_" prefix. e.g. "protected_create" instead of "create".

E.g.:

```
class MyResourceListView(flask_jsonapi.ProtectedListView):
    def protected_create(self, data, **kwargs):
        use_case = use_cases.CreateMyResourceUseCase()
        return use_case.execute(param1=data['xyz'])

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/flask-jsonapi/58)
<!-- Reviewable:end -->
