### PR TITLE
Add allowed_actions for ViewSet and View.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 1.2.1 (unreleased)
 ------------------
 
+- Add allowed_actions for ViewSet and View.
 - Allow overriding resource action methods in protected views.
 
 

--- a/flask_jsonapi/__init__.py
+++ b/flask_jsonapi/__init__.py
@@ -7,11 +7,17 @@ from .resource_repositories.repositories import ResourceRepository
 from .resource_repository_views import ResourceRepositoryDetailView
 from .resource_repository_views import ResourceRepositoryListView
 from .resource_repository_views import ResourceRepositoryViewSet
+from .resources import AllowedActionsResourceDetailMixin
+from .resources import AllowedActionsResourceListMixin
+from .resources import AllowedActionsResourceViewSetMixin
 from .resources import ResourceDetail
 from .resources import ResourceList
 
 __all__ = [
     exceptions,
+    AllowedActionsResourceDetailMixin,
+    AllowedActionsResourceListMixin,
+    AllowedActionsResourceViewSetMixin,
     Api,
     FilterField,
     FilterSchema,

--- a/flask_jsonapi/exceptions.py
+++ b/flask_jsonapi/exceptions.py
@@ -96,6 +96,19 @@ class RelationNotFound(JsonApiException):
     title = "Relation not found"
 
 
+class MethodNotAllowed(JsonApiException):
+    title = "Method not allowed"
+    status = 405
+
+    def __init__(self, detail, source=None, **kwargs):
+        source = source or {}
+        super().__init__(
+            source=source,
+            detail=detail,
+            **kwargs,
+        )
+
+
 class InvalidType(JsonApiException):
     title = "Invalid type"
     status = 409

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,61 +1,50 @@
 import collections
-import json
 
 from unittest import mock
 
 import marshmallow_jsonapi
-import pytest
 
 from marshmallow_jsonapi import fields
 
-from flask_jsonapi import api
 from flask_jsonapi import filters_schema
 from flask_jsonapi import resource_repository_views
 from flask_jsonapi import resources
 from flask_jsonapi.resource_repositories import repositories
 
-JSONAPI_HEADERS = {'content-type': 'application/vnd.api+json', 'accept': 'application/vnd.api+json'}
+
+class ExampleSchema(marshmallow_jsonapi.Schema):
+    id = fields.UUID(required=True)
+    body = fields.Str()
+
+    class Meta:
+        type_ = 'example'
+        self_view_many = 'example_list'
+        self_view = 'example_detail'
+        self_view_kwargs = {'example_id': '<id>'}
+        strict = True
 
 
-@pytest.fixture
-def example_schema():
-    class ExmapleSchema(marshmallow_jsonapi.Schema):
-        id = fields.UUID(required=True)
-        body = fields.Str()
-
-        class Meta:
-            type_ = 'example'
-            self_view_many = 'example_list'
-            self_view = 'example_detail'
-            self_view_kwargs = {'example_id': '<id>'}
-            strict = True
-    return ExmapleSchema
-
-
-@pytest.fixture
-def example_model():
+def resource_factory(id=None, body=None):
     ExampleModel = collections.namedtuple('ExampleModel', 'id body')
-    return ExampleModel
+    return ExampleModel(id=id, body=body)
 
 
-def test_integration_get_list(app, example_schema, example_model):
+def test_integration_get_list(api, jsonapi_client):
     class ExampleListView(resources.ResourceList):
-        schema = example_schema
+        schema = ExampleSchema
 
         def read_many(self, filters, sorting, pagination):
             return [
-                example_model(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='heheh'),
-                example_model(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a5', body='hihi'),
+                resource_factory(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='heheh'),
+                resource_factory(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a5', body='hihi'),
             ]
 
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().get(
-        '/examples/',
-        headers=JSONAPI_HEADERS
-    )
-    result = json.loads(response.data.decode())
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = jsonapi_client.get('/examples/')
+
     assert response.status_code == 200
+    result = response.get_json(force=True)
     assert result == {
         'data': [
             {
@@ -81,45 +70,42 @@ def test_integration_get_list(app, example_schema, example_model):
     }
 
 
-def test_sorting(app, example_schema):
+def test_sorting(api, jsonapi_client):
     class ExampleRepository(repositories.ResourceRepository):
         pass
 
     class ExampleListView(resource_repository_views.ResourceRepositoryViewSet):
-        schema = example_schema
+        schema = ExampleSchema
         repository = ExampleRepository
 
-    api.Api(app).repository(ExampleListView(), 'example', '/examples/')
+    api.repository(ExampleListView(), 'example', '/examples/')
     get_list_mock = mock.MagicMock()
+
     with mock.patch('flask_jsonapi.resource_repositories.repositories.ResourceRepository.get_list', get_list_mock):
-        app.test_client().get(
-            '/examples/?sort=body',
-            headers=JSONAPI_HEADERS
-        )
+        jsonapi_client.get('/examples/?sort=body')
+
     get_list_mock.assert_called_once_with({}, ('body',), {})
 
 
-def test_integration_get_list_with_pagination(app, example_schema, example_model):
+def test_integration_get_list_with_pagination(api, jsonapi_client):
     class ExampleListView(resources.ResourceList):
-        schema = example_schema
+        schema = ExampleSchema
 
         def read_many(self, filters, sorting, pagination):
             return [
-                example_model(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='heheh'),
-                example_model(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a5', body='hihi'),
+                resource_factory(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='heheh'),
+                resource_factory(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a5', body='hihi'),
             ]
 
         def get_count(self, filters):
             return 5
 
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().get(
-        '/examples/?page[size]=2&page[number]=1',
-        headers=JSONAPI_HEADERS
-    )
-    result = json.loads(response.data.decode())
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = jsonapi_client.get('/examples/?page[size]=2&page[number]=1')
+
     assert response.status_code == 200
+    result = response.get_json(force=True)
     assert result == {
         'data': [
             {
@@ -153,15 +139,16 @@ def test_integration_get_list_with_pagination(app, example_schema, example_model
     }
 
 
-def test_integration_bad_accept_header(app, example_schema, example_model):
+def test_integration_bad_accept_header(api, test_client):
     class ExampleListView(resources.ResourceList):
-        schema = example_schema
+        schema = ExampleSchema
 
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().get('/examples/', headers={'accept': 'text/html'})
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = test_client.get('/examples/', headers={'accept': 'text/html'})
+
     assert response.status_code == 406
-    assert json.loads(response.data.decode()) == {
+    assert response.get_json(force=True) == {
         'errors': [{
             'detail': 'Accept header must be application/vnd.api+json',
             'source': '',
@@ -174,15 +161,16 @@ def test_integration_bad_accept_header(app, example_schema, example_model):
     }
 
 
-def test_integration_bad_content_type_header(app, example_schema, example_model):
+def test_integration_bad_content_type_header(api, test_client):
     class ExampleListView(resources.ResourceList):
-        schema = example_schema
+        schema = ExampleSchema
 
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().post('/examples/', headers={'accept': 'application/vnd.api+json'})
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = test_client.post('/examples/', headers={'accept': 'application/vnd.api+json'})
+
     assert response.status_code == 415
-    assert json.loads(response.data.decode()) == {
+    assert response.get_json(force=True) == {
         'errors': [{
             'detail': 'Content-Type header must be application/vnd.api+json',
             'source': '',
@@ -195,7 +183,7 @@ def test_integration_bad_content_type_header(app, example_schema, example_model)
     }
 
 
-def test_integration_get_filtered_list(app, example_schema, example_model):
+def test_integration_get_filtered_list(api, jsonapi_client):
     class ExampleFiltersSchema(filters_schema.FilterSchema):
         basic = filters_schema.FilterField()
         listed = filters_schema.ListFilterField()
@@ -204,7 +192,7 @@ def test_integration_get_filtered_list(app, example_schema, example_model):
         skipped_filter = filters_schema.FilterField()
 
     class ExampleListView(resources.ResourceList):
-        schema = example_schema
+        schema = ExampleSchema
         filter_schema = ExampleFiltersSchema()
 
         applied_filters = {}
@@ -213,12 +201,12 @@ def test_integration_get_filtered_list(app, example_schema, example_model):
             self.applied_filters.update(filters)
             return []
 
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().get(
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = jsonapi_client.get(
         '/examples/?filter[basic]=text&filter[listed]=first,second&filter[dumb-name]=another&filter[integer]=3',
-        headers=JSONAPI_HEADERS
     )
+
     assert response.status_code == 200
     assert ExampleListView.applied_filters == {
         'basic': 'text',
@@ -228,9 +216,9 @@ def test_integration_get_filtered_list(app, example_schema, example_model):
     }
 
 
-def test_integration_pagination(app, example_schema):
+def test_integration_pagination(api, jsonapi_client):
     class ExampleListView(resources.ResourceList):
-        schema = example_schema
+        schema = ExampleSchema
 
         applied_pagination = {}
 
@@ -241,12 +229,10 @@ def test_integration_pagination(app, example_schema):
         def get_count(self, filters):
             return 0
 
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().get(
-        '/examples/?page[size]=100&page[number]=50',
-        headers=JSONAPI_HEADERS
-    )
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = jsonapi_client.get('/examples/?page[size]=100&page[number]=50')
+
     assert response.status_code == 200
     assert ExampleListView.applied_pagination == {
         'size': 100,
@@ -254,44 +240,43 @@ def test_integration_pagination(app, example_schema):
     }
 
 
-def test_integration_create_resource(app, example_schema, example_model):
+def test_integration_create_resource(api, jsonapi_client):
     class ExampleListView(resources.ResourceList):
-        schema = example_schema
+        schema = ExampleSchema
 
         def create(self, *args, **kwargs):
-            return example_model(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='Nice body.')
+            return resource_factory(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='Nice body.')
 
-    json_data = json.dumps({
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = jsonapi_client.post(
+        '/examples/',
+        json={
+            'data': {
+                'type': 'example',
+                'id': 'f60717a3-7dc2-4f1a-bdf4-f2804c3127a4',
+                'attributes': {
+                    'body': "Nice body.",
+                }
+            }
+        },
+    )
+
+    assert response.get_json(force=True) == {
         'data': {
             'type': 'example',
             'id': 'f60717a3-7dc2-4f1a-bdf4-f2804c3127a4',
             'attributes': {
-                'body': "Nice body.",
-            }
-        }
-    })
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().post(
-        '/examples/',
-        headers=JSONAPI_HEADERS,
-        data=json_data,
-    )
-    assert json.loads(response.data.decode()) == {
-        "data": {
-            "type": "example",
-            "id": "f60717a3-7dc2-4f1a-bdf4-f2804c3127a4",
-            "attributes": {
-                "body": "Nice body."
+                'body': 'Nice body.'
             }
         },
-        "jsonapi": {
-            "version": "1.0"
+        'jsonapi': {
+            'version': '1.0'
         }
     }
 
 
-def test_integration_create_resource_invalid_input(app, example_schema, example_model):
+def test_integration_create_resource_invalid_input(api, jsonapi_client):
     class TestSchema(marshmallow_jsonapi.Schema):
         id = fields.UUID()
         f1 = fields.Str(required=True)
@@ -305,25 +290,24 @@ def test_integration_create_resource_invalid_input(app, example_schema, example_
         schema = TestSchema
 
         def create(self, *args, **kwargs):
-            return example_model(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='Nice body.')
+            return resource_factory(id='f60717a3-7dc2-4f1a-bdf4-f2804c3127a4', body='Nice body.')
 
-    json_data = json.dumps({
-        'data': {
-            'type': 'test',
-        }
-    })
-    application_api = api.Api(app)
-    application_api.route(ExampleListView, 'example_list', '/examples/')
-    response = app.test_client().post(
+    api.route(ExampleListView, 'example_list', '/examples/')
+
+    response = jsonapi_client.post(
         '/examples/',
-        headers=JSONAPI_HEADERS,
-        data=json_data,
+        json={
+            'data': {
+                'type': 'test',
+            }
+        }
     )
-    result = json.loads(response.data.decode())
+
+    result = response.get_json(force=True)
     assert result == {
         'errors': mock.ANY,
-        "jsonapi": {
-            "version": "1.0"
+        'jsonapi': {
+            'version': '1.0'
         }
     }
     assert list(sorted(result['errors'], key=lambda x: x['source']['pointer'])) == [
@@ -337,21 +321,18 @@ def test_integration_create_resource_invalid_input(app, example_schema, example_
     ]
 
 
-def test_integration_get(app, example_schema, example_model):
-
+def test_integration_get(api, jsonapi_client):
     class ExampleDetailView(resources.ResourceDetail):
-        schema = example_schema
+        schema = ExampleSchema
 
         def read(self, id):
-            return example_model(id=id, body='Gwynbelidd')
+            return resource_factory(id=id, body='Gwynbelidd')
 
-    application_api = api.Api(app)
-    application_api.route(ExampleDetailView, 'example_detail', '/examples/<id>/')
-    response = app.test_client().get(
-        '/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/',
-        headers=JSONAPI_HEADERS
-    )
-    result = json.loads(response.data.decode())
+    api.route(ExampleDetailView, 'example_detail', '/examples/<id>/')
+
+    response = jsonapi_client.get('/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/')
+
+    result = response.get_json(force=True)
     assert response.status_code == 200
     assert result == {
         'data': {
@@ -367,107 +348,97 @@ def test_integration_get(app, example_schema, example_model):
     }
 
 
-def test_integration_delete(app, example_schema, example_model):
+def test_integration_delete(api, jsonapi_client):
 
     class ExampleDetailView(resources.ResourceDetail):
-        schema = example_schema
+        schema = ExampleSchema
         deleted_ids = []
 
         def destroy(self, id):
             self.deleted_ids.append(id)
 
-    application_api = api.Api(app)
-    application_api.route(ExampleDetailView, 'example_detail', '/examples/<id>/')
-    response = app.test_client().delete(
-        '/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/',
-        headers=JSONAPI_HEADERS
-    )
+    api.route(ExampleDetailView, 'example_detail', '/examples/<id>/')
+
+    response = jsonapi_client.delete('/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/')
+
     assert response.status_code == 204
     assert response.data == b''
     assert ExampleDetailView.deleted_ids == ['f60717a3-7dc2-4f1a-bdf4-f2804c3127a4']
 
 
-def test_integration_patch(app, example_schema, example_model):
-
+def test_integration_patch(api, jsonapi_client):
     class ExampleDetailView(resources.ResourceDetail):
-        schema = example_schema
+        schema = ExampleSchema
 
-        def update(self, id, data):
+        def update(self, id, data, **kwargs):
             data.pop('id')
-            return example_model(id=id, **data)
+            return resource_factory(id=id, **data)
 
-    json_data = json.dumps({
+    api.route(ExampleDetailView, 'example_list', '/examples/<id>/')
+
+    response = jsonapi_client.patch(
+        '/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/',
+        json={
+            'data': {
+                'type': 'example',
+                'id': 'f60717a3-7dc2-4f1a-bdf4-f2804c3127a4',
+                'attributes': {
+                    'body': 'Nice body.',
+                }
+            }
+        }
+    )
+
+    assert response.get_json(force=True) == {
         'data': {
             'type': 'example',
             'id': 'f60717a3-7dc2-4f1a-bdf4-f2804c3127a4',
             'attributes': {
-                'body': "Nice body.",
-            }
-        }
-    })
-    application_api = api.Api(app)
-    application_api.route(ExampleDetailView, 'example_list', '/examples/<id>/')
-    response = app.test_client().patch(
-        '/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/',
-        headers=JSONAPI_HEADERS,
-        data=json_data,
-    )
-    assert json.loads(response.data.decode()) == {
-        "data": {
-            "type": "example",
-            "id": "f60717a3-7dc2-4f1a-bdf4-f2804c3127a4",
-            "attributes": {
-                "body": "Nice body."
+                'body': 'Nice body.'
             }
         },
-        "jsonapi": {
-            "version": "1.0"
+        'jsonapi': {
+            'version': '1.0'
         }
     }
 
 
-def test_integration_patch_with_empty_response(app, example_schema, example_model):
-
+def test_integration_patch_with_empty_response(api, jsonapi_client):
     class ExampleDetailView(resources.ResourceDetail):
-        schema = example_schema
+        schema = ExampleSchema
 
-        def update(self, id, data):
+        def update(self, id, data, **kwargs):
             pass
 
-    json_data = json.dumps({
-        'data': {
-            'type': 'example',
-            'id': 'f60717a3-7dc2-4f1a-bdf4-f2804c3127a4',
-            'attributes': {
-                'body': "Nice body.",
+    api.route(ExampleDetailView, 'example_list', '/examples/<id>/')
+
+    response = jsonapi_client.patch(
+        '/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/',
+        json={
+            'data': {
+                'type': 'example',
+                'id': 'f60717a3-7dc2-4f1a-bdf4-f2804c3127a4',
+                'attributes': {
+                    'body': 'Nice body.',
+                }
             }
         }
-    })
-    application_api = api.Api(app)
-    application_api.route(ExampleDetailView, 'example_list', '/examples/<id>/')
-    response = app.test_client().patch(
-        '/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/',
-        headers=JSONAPI_HEADERS,
-        data=json_data,
     )
+
     assert response.status_code == 204
     assert response.data == b''
 
 
-def test_creating_view_with_dynamic_schema(app, example_schema, example_model):
+def test_creating_view_with_dynamic_schema(api, jsonapi_client):
     class ExampleDetailView(resources.ResourceDetail):
-
         def read(self, id):
-            return example_model(id=id, body='Gwynbelidd')
+            return resource_factory(id=id, body='Gwynbelidd')
 
-    application_api = api.Api(app)
-    application_api.route(ExampleDetailView, 'example_detail', '/examples/<id>/',
-                          view_kwargs={'schema': example_schema})
-    response = app.test_client().get(
-        '/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/',
-        headers=JSONAPI_HEADERS
-    )
-    result = json.loads(response.data.decode())
+    api.route(ExampleDetailView, 'example_detail', '/examples/<id>/', view_kwargs={'schema': ExampleSchema})
+
+    response = jsonapi_client.get('/examples/f60717a3-7dc2-4f1a-bdf4-f2804c3127a4/')
+
+    result = response.get_json(force=True)
     assert result == {
         'data': {
             'id': 'f60717a3-7dc2-4f1a-bdf4-f2804c3127a4',


### PR DESCRIPTION
When using the ResourceRepositoryViewSet class, all the available resource actions are available on the endpoint by default. It's difficult to block certain actions, like "delete", as this requires creating custom ListView / DetailView classes only to raise an exception.
This PR adds an optional mixin that can be used to disallow all actions by default and explicitly state which ones are allowed.

Example (all actions are allowed by default):
```
class MyResourceViewSet(flask_jsonapi.ResourceRepositoryViewSet):
    schema = schemas.MySchema
    repository = repositories.MyRepository()
```

Example (allowed actions are limited to "read" and "read_many"):
```
class MyResourceDetailView(flask_jsonapi.AllowedActionsResourceDetailMixin, flask_jsonapi.ResourceRepositoryDetailView):
    pass

class MyResourceListView(flask_jsonapi.AllowedActionsResourceListMixin, flask_jsonapi.ResourceRepositoryListView):
    pass

class MyResourceViewSet(flask_jsonapi.AllowedActionsResourceViewSetMixin, flask_jsonapi.ResourceRepositoryViewSet):
    schema = schemas.MySchema
    repository = repositories.MyRepository()
    detail_view_cls = MyResourceDetailView    
    list_view_cls = MyResourceListView
    allowed_actions = (
        resources.Actions.read,
        resources.Actions.read_many,
    )

```

We encourage you to make this the default behavior for your app (deny by default, only allow access explicitly). Introducing a base ViewSet class will help.

Example:
File `base.py`
```
class BaseDetailView(flask_jsonapi.AllowedActionsResourceDetailMixin, flask_jsonapi.ResourceRepositoryDetailView):
    pass

class BaseListView(flask_jsonapi.AllowedActionsResourceListMixin, flask_jsonapi.ResourceRepositoryListView):
    pass

class BaseViewSet(flask_jsonapi.AllowedActionsResourceViewSetMixin, flask_jsonapi.ResourceRepositoryViewSet):
    detail_view_cls = MyResourceDetailView    
    list_view_cls = MyResourceListView
```
File `endpoints.py`:
```
from flask_jsonapi import resources

from my_app import base, repositories, schemas


class MyResourceViewSet(base.BaseViewSet):
    schema = schemas.MySchema
    repository = repositories.MyRepository()
    allowed_actions = (
        resources.Actions.read,
        resources.Actions.read_many,
    )
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/flask-jsonapi/59)
<!-- Reviewable:end -->
